### PR TITLE
Varies fixes and further quality of life changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A way more advanced version of the original [DOC](https://github.com/tonytins/fb
 
 - [x] Migrate away from table layout
 - [ ] Write comic architecture
+- [ ] Move attribution and copyright architecture to its own component
 - [ ] Target .NET 8
 - [ ] Turn into template for future projects
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@
 
 [![GitHub license](https://img.shields.io/github/license/tonytins/cudoc)](https://github.com/tonytins/cudoc/blob/master/LICENSE) [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0%20adopted-ff69b4.svg)](CODE_OF_CONDUCT.md)
 
----
-
-A way more advanced version of the original [D.O.C.](https://github.com/tonytins/fbdoc) website, based on .NET 7+ and Blazor WebAssembly.
+A way more advanced version of the original [DOC](https://github.com/tonytins/fbdoc) website, based on .NET 7+ and Blazor WebAssembly.
 
 ## To-do
 
@@ -20,11 +18,11 @@ A way more advanced version of the original [D.O.C.](https://github.com/tonytins
 | Continuous Integration | ![Build](https://github.com/tonytins/cudoc/workflows/Build%20⚙️/badge.svg)   |
 | Github Pages           | ![Deploy](https://github.com/tonytins/cudoc/workflows/Deploy%20🚀/badge.svg) |
 
-## Background
+## Contributing
 
-Inspired by Cartoon Network, I created DOC as the Furry Blue DOC when I was 17 using Microsoft Frontpage 2003. I learned Frontpage back when mom brought me to some of her collage classes. I eventually installed it myself onto future desktops, at that time, to create my own websites. For reference, the artwork on this site dates back two years prior to the original site's creation. Sometime later I attempted to maintain it using Dreamweaver 8 when I moved to macOS.
+Casey Universe DOC is **free, open-source software** licensed under **AGPLv3**.
 
-It wasn't until recently that I rediscovered it again in old cloud backup containing some art I previously considered lost. I restored and cleaned up to the best of my ability until I realized how complex the simple looking site really was underneath. Having moved on from WYSIWYG editors, I migrated the codebase to it once I discovered .NET 7 and Blazor WebAssembly using thier blank templates. Funny, how I've come full circle in using Microsoft's products. xD
+You can open issues for bugs you've found or features you think are missing. You can also submit pull requests to this repository.
 
 ## License
 

--- a/src/CaseyUniverse.DOC/CaseyUniverse.DOC.csproj
+++ b/src/CaseyUniverse.DOC/CaseyUniverse.DOC.csproj
@@ -1,23 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
-
- <PropertyGroup>
-  <TargetFramework>net7.0</TargetFramework>
-  <Nullable>enable</Nullable>
-  <ImplicitUsings>enable</ImplicitUsings>
- </PropertyGroup>
-
- <PropertyGroup Condition=" '$(RunConfiguration)' == 'https' ">
-  <ExternalConsole>true</ExternalConsole>
- </PropertyGroup>
- <PropertyGroup Condition=" '$(RunConfiguration)' == 'http' ">
-  <ExternalConsole>true</ExternalConsole>
- </PropertyGroup>
- <ItemGroup>
-  <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="7.0.4" />
-  <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="7.0.4" PrivateAssets="all" />
-  <PackageReference Include="Markdig" Version="0.31.0" />
-  <PackageReference Include="HtmlSanitizer" Version="8.0.645" />
-  <PackageReference Include="CsvHelper" Version="30.0.1" />
- </ItemGroup>
-
+	<PropertyGroup>
+		<TargetFramework>net7.0</TargetFramework>
+		<Nullable>enable</Nullable>
+		<ImplicitUsings>enable</ImplicitUsings>
+	</PropertyGroup>
+	<PropertyGroup Condition=" '$(RunConfiguration)' == 'https' ">
+		<ExternalConsole>true</ExternalConsole>
+	</PropertyGroup>
+	<PropertyGroup Condition=" '$(RunConfiguration)' == 'http' ">
+		<ExternalConsole>true</ExternalConsole>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="7.0.4" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="7.0.4" PrivateAssets="all" />
+		<PackageReference Include="Markdig" Version="0.31.0" />
+		<PackageReference Include="HtmlSanitizer" Version="8.0.645" />
+		<PackageReference Include="CsvHelper" Version="30.0.1" />
+	</ItemGroup>
 </Project>

--- a/src/CaseyUniverse.DOC/CaseyUniverse.DOC.csproj
+++ b/src/CaseyUniverse.DOC/CaseyUniverse.DOC.csproj
@@ -17,5 +17,6 @@
 		<PackageReference Include="Markdig" Version="0.31.0" />
 		<PackageReference Include="HtmlSanitizer" Version="8.0.645" />
 		<PackageReference Include="CsvHelper" Version="30.0.1" />
+		<PackageReference Include="YamlDotNet" Version="13.0.2" />
 	</ItemGroup>
 </Project>

--- a/src/CaseyUniverse.DOC/Components/DynMeta.razor
+++ b/src/CaseyUniverse.DOC/Components/DynMeta.razor
@@ -14,20 +14,15 @@ else
         <meta content="@Image" property="og:image" data-rh="true">
     }
     <meta name="title" content="@Name - @GlobalConsts.SITE_NAME" property="og:title" data-rh="true">
-    @if (!string.IsNullOrEmpty(Description))
-    {
-        <meta description="@Description" name="description" data-rh="true">
-        <meta name="description" content="@Description" property="og:description" data-rh="true">
-    }
 </HeadContent>
 <div>
     @if (Heading)
     {
         <h2>@Name</h2>
     }
-    @if (!string.IsNullOrEmpty(Description))
+    @if (!string.IsNullOrEmpty(Authors))
     {
-        <p>@Description</p>
+        <sup>By @Authors</sup>
     }
 </div>
 
@@ -45,6 +40,9 @@ else
     [Parameter]
     public bool Heading { get; set; } = true;
 
+    [Parameter]
+    public string Authors { get; set; } = string.Empty;
+
     /// <summary>
     /// The image URL to use for Open Graph meta tags.
     /// </summary>
@@ -56,12 +54,6 @@ else
     /// </summary>
     [Parameter]
     public string? PreviousPage { get; set; } = string.Empty;
-
-    /// <summary>
-    /// The description of the current page to use for Open Graph meta tags.
-    /// </summary>
-    [Parameter]
-    public string? Description { get; set; } = string.Empty;
 
 }
 

--- a/src/CaseyUniverse.DOC/Components/Views/Media.razor
+++ b/src/CaseyUniverse.DOC/Components/Views/Media.razor
@@ -13,10 +13,9 @@
     }
     else
     {
-        <DynMeta Description="@Description" PreviousPage="@PathTitle" Name="@Title" />
-        @if (!string.IsNullOrEmpty(Markdown)
-&& Filename.Contains("md", StringComparison.CurrentCultureIgnoreCase))
+        @if (Path.Contains("stories"))
         {
+            <DynMeta Authors="@Authors" PreviousPage="@PathTitle" Name="@Title" />
             <div class="story">
                 <p>
                     @Markdown.MarkdownToHtml()
@@ -25,6 +24,7 @@
         }
         else
         {
+            <DynMeta PreviousPage="@PathTitle" Name="@Title" />
             <div align="center" class="submission">
                 <img src="/images/@Path/@Filename" />
                 @if (!string.IsNullOrEmpty(Copyright))
@@ -61,11 +61,6 @@ catch
     string Filename { get; set; } = string.Empty;
 
     /// <summary>
-    /// The description of the gallery item being displayed.
-    /// </summary>
-    string Description { get; set; } = string.Empty;
-
-    /// <summary>
     /// The title of the gallery item being displayed.
     /// </summary>
     string Title { get; set; } = string.Empty;
@@ -79,6 +74,8 @@ catch
     /// Indicates whether the gallery item has finished loading.
     /// </summary>
     bool IsReady { get; set; } = false;
+
+    string Authors { get; set; } = string.Empty;
 
     string Copyright { get; set; } = string.Empty;
 
@@ -111,14 +108,14 @@ catch
 
             // Set the filename and load the markdown content if it exists.
             Filename = csv.Filename;
-            if (Filename.Contains("md", StringComparison.CurrentCultureIgnoreCase))
+            if (Path.Contains("stories"))
             {
                 var mdfile = _client.GetStringAsync($"{csv.Path}/{csv.Filename}");
                 var mdContent = await mdfile;
+                var metadata = mdContent.GetFrontMatter<Story>();
                 Markdown = mdContent;
+                Authors = !string.IsNullOrEmpty(metadata.Authors) ? metadata.Authors : Authors;
             }
-
-            Description = !string.IsNullOrWhiteSpace(csv.Description) ? csv.Description : Description;
 
             // Determine the page title, which is either the title in the CSV file or the filename with some
             // transformations applied to make it more readable.
@@ -153,10 +150,16 @@ catch
                     switch (true)
                     {
                         case true when Title.Contains("By"):
-                            copyright = Title.Split("By").Last();
-                            break;
+                            {
+                                copyright = Title.Split("By").Last();
+                                Title = Title.Split("By").First();
+                                break;
+                            }
                         case true when Title.Contains("by"):
-                            copyright = Title.Split("by").Last();
+                            {
+                                copyright = Title.Split("by").Last();
+                                Title = Title.Split("by").First();
+                            }
                             break;
                     }
 

--- a/src/CaseyUniverse.DOC/Components/Views/Media.razor
+++ b/src/CaseyUniverse.DOC/Components/Views/Media.razor
@@ -6,7 +6,12 @@
 @* Displays an image or markdown file based on the file extension and provides a link to the page where the file was found. *@
 @try
 {
-    @if (IsReady)
+    @if (!IsReady)
+    {
+
+        <LoadingBar />
+    }
+    else
     {
         <DynMeta Description="@Description" PreviousPage="@PathTitle" Name="@Title" />
         @if (!string.IsNullOrEmpty(Markdown)
@@ -31,10 +36,6 @@
         <p align="center">
             Return to <a href="/@Path">@PathTitle</a> page
         </p>
-    }
-    else
-    {
-        <LoadingBar />
     }
 }
 catch
@@ -86,6 +87,9 @@ catch
     /// </summary>
     string ErrorMessage { get; set; } = string.Empty;
 
+    /// <summary>
+    /// The title of the path being displayed.
+    /// </summary>
     string PathTitle { get; set; } = string.Empty;
 
     /// <summary>
@@ -118,12 +122,9 @@ catch
 
             // Determine the page title, which is either the title in the CSV file or the filename with some
             // transformations applied to make it more readable.
-            switch (!string.IsNullOrWhiteSpace(csv.Title))
+            switch (string.IsNullOrWhiteSpace(csv.Title))
             {
                 case true:
-                    Title = csv.Title;
-                    break;
-                case false:
                     var oldName = Filename;
                     var zFullname = "Zack";
 
@@ -135,11 +136,16 @@ catch
 
                     Title = txtInfo.ToTitleCase(oldName);
                     break;
+                case false:
+                    Title = csv.Title;
+                    break;
             }
 
-            switch (!Path.Contains("gallery"))
+            switch (Path.Contains("gallery"))
             {
                 case true:
+                    break;
+                case false:
                     // Determine copyright information for non-gallery items.
                     var copyright = string.Empty;
 

--- a/src/CaseyUniverse.DOC/GalleryDB.cs
+++ b/src/CaseyUniverse.DOC/GalleryDB.cs
@@ -22,8 +22,7 @@ public class GalleryDB
                     Id = record.Id,
                     Filename = record.Filename,
                     Title = record.Title,
-                    Path = record.Path,
-                    Description = record.Description
+                    Path = record.Path
                 };
             }
         }
@@ -51,8 +50,7 @@ public class GalleryDB
                     Id = record.Id,
                     Filename = record.Filename,
                     Title = record.Title,
-                    Path = record.Path,
-                    Description = record.Description
+                    Path = record.Path
                 };
             }
         }

--- a/src/CaseyUniverse.DOC/MarkdownParser.cs
+++ b/src/CaseyUniverse.DOC/MarkdownParser.cs
@@ -1,0 +1,86 @@
+using System;
+using Markdig;
+using Markdig.Extensions.Yaml;
+using YamlDotNet.Serialization;
+using Markdig.Syntax;
+using Microsoft.AspNetCore.Components;
+
+namespace CaseyUniverse.DOC;
+
+public static class MarkdownParser
+{
+
+    static readonly IDeserializer YamlDeserializer =
+    new DeserializerBuilder()
+    .IgnoreUnmatchedProperties()
+    .Build();
+
+    static readonly MarkdownPipeline Pipeline
+        = new MarkdownPipelineBuilder()
+        .UseYamlFrontMatter()
+        .Build();
+
+    /// <summary>
+    /// Converts a Markdown-formatted string to an HTML-formatted string.
+    /// </summary>
+    /// <param name="content">The Markdown-formatted string to convert.</param>
+    /// <returns>An HTML-formatted string.</returns>
+    public static MarkupString MarkdownToHtml(this string content)
+    {
+        switch (string.IsNullOrEmpty(content))
+        {
+            case true:
+                return (MarkupString)string.Empty;
+            case false:
+                {
+                    var pipeline = new MarkdownPipelineBuilder()
+                        .UseSmartyPants()
+                        .UseYamlFrontMatter()
+                        .DisableHtml()
+                        .Build();
+
+                    return (MarkupString)Markdown.ToHtml(content, pipeline);
+                }
+        }
+    }
+
+    /// <summary>
+    /// Parses YAML front matter from the given markdown string.
+    /// </summary>
+    /// <typeparam name="T">The type of the front matter.</typeparam>
+    /// <param name="markdown">The markdown string to parse the front matter from.</param>
+    /// <returns>The front matter object of type T.</returns>
+    public static T GetFrontMatter<T>(this string markdown)
+    {
+        // Parse the markdown document
+        var document = Markdown.Parse(markdown, Pipeline);
+
+        // Find the YAML front matter block
+        var block = document
+            .Descendants<YamlFrontMatterBlock>()
+            .FirstOrDefault();
+
+        // Return null if the front matter is not present
+        if (block == null)
+            return default;
+
+        // Extract the YAML front matter as a string
+        var yaml =
+            block
+            // this is not a mistake
+            // we have to call .Lines 2x
+            .Lines // StringLineGroup[]
+            .Lines // StringLine[]
+            .OrderByDescending(x => x.Line)
+            .Select(x => $"{x}\n")
+            .ToList()
+            .Select(x => x.Replace("---", string.Empty))
+            .Where(x => !string.IsNullOrWhiteSpace(x))
+            .Aggregate((s, agg) => agg + s);
+
+        // Deserialize the YAML front matter into an object of type T
+        return YamlDeserializer.Deserialize<T>(yaml);
+    }
+}
+
+

--- a/src/CaseyUniverse.DOC/Models/Gallery.cs
+++ b/src/CaseyUniverse.DOC/Models/Gallery.cs
@@ -8,5 +8,4 @@ public record Gallery : IDatabase
     [Name("Filename")] public string Filename { get; set; } = string.Empty;
     [Name("Title")] public string Title { get; set; } = string.Empty;
     [Name("Path")] public string Path { get; set; } = string.Empty;
-    [Name("Description")] public string Description { get; set; } = string.Empty;
 }

--- a/src/CaseyUniverse.DOC/Models/Story.cs
+++ b/src/CaseyUniverse.DOC/Models/Story.cs
@@ -1,0 +1,9 @@
+using YamlDotNet.Serialization;
+
+namespace CaseyUniverse.DOC.Models;
+
+public record Story
+{
+    [YamlMember(Alias = "description")] public string Description { get; set; } = string.Empty;
+    [YamlMember(Alias = "authors")] public string Authors { get; set; } = string.Empty;
+}

--- a/src/CaseyUniverse.DOC/Pages/Copyright/Index.razor
+++ b/src/CaseyUniverse.DOC/Pages/Copyright/Index.razor
@@ -14,13 +14,14 @@
             <li>Coshi Dragonite</li>
             <li>Terry</li>
             <li>Zamie Cat</li>
+            <li>Kumori</li>
         </ul>
     </div>
     <div class="column">
         <ul>
             <li>Sonic the Hedgehog</li>
             <li>Shadow the Hedgehog</li>
-            <li>Gir</li>
+            <li>Gir (Invader Zim)</li>
             <li>Teki</li>
             <li>Sleepi Bunni</li>
             <li>o0obubbleso0o</li>

--- a/src/CaseyUniverse.DOC/Pages/Gallery.razor
+++ b/src/CaseyUniverse.DOC/Pages/Gallery.razor
@@ -1,7 +1,11 @@
 ﻿@page "/gallery"
 @inject HttpClient http
 <DynMeta Name="Gallery" />
-@if (_isReady)
+@if (_submissions == null)
+{
+    <LoadingBar />
+}
+else
 {
     <div class="row">
         @foreach (var submission in _submissions)
@@ -12,14 +16,9 @@
         }
     </div>
 }
-else
-{
-    <LoadingBar />
-}
 
 @code {
     List<string> _submissions = new List<string>();
-    bool _isReady = false;
 
     protected override async Task OnParametersSetAsync()
     {
@@ -34,9 +33,6 @@ else
             images.Remove(buddy);
 
         _submissions = images;
-
-        // Set the flag to indicate that the component is ready
-        _isReady = true;
     }
 }
 

--- a/src/CaseyUniverse.DOC/SiteHelper.cs
+++ b/src/CaseyUniverse.DOC/SiteHelper.cs
@@ -49,16 +49,21 @@ public static class SiteHelper
     /// <returns>An HTML-formatted string.</returns>
     public static MarkupString MarkdownToHtml(this string content)
     {
-        if (!string.IsNullOrEmpty(content))
+        switch (string.IsNullOrEmpty(content))
         {
-            var pipeline = new MarkdownPipelineBuilder()
-                .DisableHtml()
-                .Build();
+            case true:
+                return (MarkupString)string.Empty;
+            case false:
+                {
+                    var pipeline = new MarkdownPipelineBuilder()
+                        .UseSmartyPants()
+                        .UseYamlFrontMatter()
+                        .DisableHtml()
+                        .Build();
 
-            return (MarkupString)Markdown.ToHtml(content, pipeline);
+                    return (MarkupString)Markdown.ToHtml(content, pipeline);
+                }
         }
-        else
-            return (MarkupString)string.Empty;
     }
 
 }

--- a/src/CaseyUniverse.DOC/SiteHelper.cs
+++ b/src/CaseyUniverse.DOC/SiteHelper.cs
@@ -1,5 +1,6 @@
 using Markdig;
 using Microsoft.AspNetCore.Components;
+
 namespace CaseyUniverse.DOC;
 
 /// <summary>
@@ -40,30 +41,6 @@ public static class SiteHelper
         using var reader = new StreamReader(csv);
         using var file = new CsvReader(reader, CultureInfo.InvariantCulture);
         return file.GetRecords<IDatabase>().ToList();
-    }
-
-    /// <summary>
-    /// Converts a Markdown-formatted string to an HTML-formatted string.
-    /// </summary>
-    /// <param name="content">The Markdown-formatted string to convert.</param>
-    /// <returns>An HTML-formatted string.</returns>
-    public static MarkupString MarkdownToHtml(this string content)
-    {
-        switch (string.IsNullOrEmpty(content))
-        {
-            case true:
-                return (MarkupString)string.Empty;
-            case false:
-                {
-                    var pipeline = new MarkdownPipelineBuilder()
-                        .UseSmartyPants()
-                        .UseYamlFrontMatter()
-                        .DisableHtml()
-                        .Build();
-
-                    return (MarkupString)Markdown.ToHtml(content, pipeline);
-                }
-        }
     }
 
 }

--- a/src/CaseyUniverse.DOC/wwwroot/css/common.css
+++ b/src/CaseyUniverse.DOC/wwwroot/css/common.css
@@ -162,6 +162,10 @@ html:not([data-scroll='0']) header {
     top: 0;
     z-index: 1;
     /* This box-shadow will help sell the floating effect */
-    box-shadow: 0 0 0.5em rgba(0, 0, 0, 0.5);
     padding-bottom: 2px;
+}
+
+html:not([data-scroll='0']) .topnav {
+    /* This box-shadow will help sell the floating effect */
+    box-shadow: 0 0 0.5em rgba(0, 0, 0, 0.5);
 }

--- a/src/CaseyUniverse.DOC/wwwroot/data/gallery.csv
+++ b/src/CaseyUniverse.DOC/wwwroot/data/gallery.csv
@@ -1,148 +1,148 @@
-Id,Filename,Path,Title,Description
-1963,fbdj_wallpaper.png,wallpaper,Furry Blue DJ,
-4858,feet_wallpaper.png,wallpaper,Feet!,
-1198,mu_wallpaper.png,wallpaper,Mu,
-2983,vector_gen_wallpaper.png,wallpaper,Vector Generation,
-5059,fanart_wallpaper.png,wallpaper,Fanart Collage,
-6815,z_artists_fanclub.png,wallpaper,Z-Artists’ Club by Megawolf77,
-1878,christmas_yet.png,wallpaper,Is it Christmas Yet?,
-7567,ferret_girl_ch1.md,stories,"Curse of the Ferret Girl, Chapter 1",Written by Travis-uped. Rewritten by ChatGPT.
-9268,ferret_girl_ch2.md,stories,"Curse of the Ferret Girl, Chapter 2",Written by Tony Bark. Rewritten by ChatGPT.
-6651,Friends_in_Kimono_by_Popochi.gif,gifts,,
-2805,OMG_She_Killed_Mega_by_Coshi_Dragonite.jpg,gifts,,
-8067,Z_Marble_by_travisuped.jpg,gifts,,
-1422,TJ_by_travisuped.jpg,gifts,,
-3593,Oops_by_watthaduece.jpg,gifts,,
-5431,YAY_for_Zc456_by_Popochi.jpg,gifts,,
-2228,Zs_house_went_BOOOM_by_nannu901.jpg,gifts,,
-3128,Make_em_laugh by_ZamieCat.jpg,gifts,,
-1019,Think_Z_by_watthaduece 2.jpg,gifts,Think Z by Watthaduece,
-3164,zcfan_by_Travis-uped.jpg,gifts,Zack Fan by Travis-uped,
-2976,z_yahoo_doodle_by_Megawolf77.png,gifts,,
-3650,Stop_n_Swop__by_Milkb0ne.jpg,gifts,,
-4607,1st_drawing_of_Z_by_Netoko.png,gifts,,
-8149,ZC_Fanart_by_KawaiiNanao.jpg,gifts,,
-5212,zc456_got_700_pageviews_by_megawolf77.jpg,gifts,,
-3876,Kumori_and_ZC_by_KumoriAikou.jpg,gifts,,
-4924,To_Z_by_wild_catgirl_washu.gif,gifts,,
-5531,zcfan_colored_by_Travis-uped.jpg,gifts,Zack Fan Colored by Travis-uped,
-8942,ZC_by_KumoriAikou.jpg,gifts,,
-3119,good_bad_insane_by_shadowwolfmidnight.jpg,gifts,,
-8349,It_Angst_Easy_Being_Z_by_watthaduece.jpg,gifts,,
-7427,13_K_hits_for_Megawolf_by_Coshi_Dragonite.jpg,gifts,,
-5991,ZC_tweakin_by_JamesRocket.png,gifts,,
-8567,Think_Z_by_watthaduece.jpg,gifts,,
-1467,Zc_D_by_CheetahGal.jpg,gifts,,
-6831,Z_Beats_for_Z_Artists_contest__by_megawolf77.png,gifts,,
-9767,28_K_for_Lilchu_by_Coshi_Dragonite.jpg,gifts,,
-2824,ifIgothacked.jpg,gifts,If I Got Hacked by Travis-uped,
-6621,ZC_against_Terry_by_JamesRocket.png,gifts,,
-9698,Zc456_Zero_Punctuation_by_Midnight_Vulpin.jpg,gifts,,
-5014,ZC_thinks_about_cooking_by_JamesRocket.png,gifts,,
-2972,Zc456_has_a_problem_by_Milkb0ne.jpg,gifts,,
-3716,Plant_a_Z_Today_by_watthaduece.jpg,gifts,,
-7631,Zs_Pocky_Obsession_by_wild_catgirl_washu.jpg,gifts,,
-8442,attack_of_the_video_games.gif,animations,Attack of the Video Games,
-4294,school.gif,animations,School!,
-5264,a_dog.gif,animations,If I Were a Dog,
-1743,not_a_puppy.gif,animations,Not a Puppy!,
-7168,rvb_z_welcome.png,gallery,Red vs Blue,
-1371,black_and_white.png,gallery,,
-4234,3k_views.png,gallery,,
-6185,you_know_wanna.png,gallery,,
-8727,plant_your_butt.png,gallery,,
-1502,zc_paint.png,gallery,MS Paint Zack,
-9312,above_the_world.png,gallery,Us Against the World,
-9866,z_meets_roboz.png,gallery,Zack Meets RoboZ,
-2853,sleeping.png,gallery,,
-2471,z_goes_camping.png,gallery,Zack Goes Camping,
-8729,her_butt_blew_up.png,gallery,,
-231,zc_paint_v2.png,gallery,MS Paint Zack v2,
-8171,be_my_buddy.png,gallery,,
-9215,it_itchs_-_remix.png,gallery,,
-6456,spit_bomber_tails.png,gallery,,
-3694,gaia_zack.png,gallery,Gaia Zack,
-7288,speachless.png,gallery,,
-4862,bluefreak.png,gallery,Blue Freak,
-9668,moo_XD.png,gallery,Zack with Udders,
-1399,mr_green.gif,gallery,,
-7718,twilight_z.png,gallery,Twilight Zack,
-9097,the_pepsi.png,gallery,,
-4467,on_the_train.png,gallery,Night on the Train,
-4481,Wonka-z.png,gallery,Wonka Zack,
-9185,fried_brain.png,gallery,,
-9329,z_djs.jpg,gallery,Zack DJs,
-8132,z_gets_flashed.png,gallery,Zack Gets Flashed,
-9918,my_green_eggs_and_ham.png,gallery,,
-7814,the_future_dj.png,gallery,The Future DJ,
-2837,my_brown_poo.png,gallery,,
-5247,a_random_hug.png,gallery,,
-8095,z_meet_bunni.jpg,gallery,Zack Meets Bunni,
-7430,Doom_Flakes.png,gallery,,
-8759,alex.png,gallery,,
-2173,z_adorable2-5.png,gallery,Adoble Zack 2.5,
-8048,is_it_christmas.png,gallery,Is it Christmas Yet?,
-2566,Doom_Flakes_-_Popochi.png,gallery,,
-1854,killed_sally.png,gallery,,
-3993,do_the_bunni.png,gallery,Do the Bunni!,
-7025,boxers_of_america.png,gallery,,
-5555,get_something_done.png,gallery,,
-5869,singing_satellite.gif,gallery,,
-4457,zc_2_pixal.png,gallery,Pixel Zack v2,
-4126,John_Model_Sheet.png,gallery,John,
-7973,kim.png,gallery,,
-2962,zc_smile.gif,gallery,Smiley,
-7149,woof.png,gallery,,
-2657,battery_park.png,gallery,,
-7481,gir.png,gallery,,
-7312,it_itchs.png,gallery,,
-5787,Torro.png,gallery,,
-3768,my_tail.jpg,gallery,Keep the Fox Tail,
-4384,evil_mw77.png,gallery,Evil Mega,
-6122,whos_the_cute_one.png,gallery,Who's the Cute One?,
-8215,link_gets_a_hug.png,gallery,,
-9289,cat_z.png,gallery,,
-3724,rain_go_away.png,gallery,"Rain, Rain Go Away",
-9685,you.png,gallery,You!!!,
-1254,super_z.png,gallery,Super Zack!,
-3111,for_sam.png,gallery,,
-1423,me_as_a_fox.png,gallery,,
-7867,mw77.png,gallery,Toon(ish) Mega,
-9110,z_kitten_model_sheet_1.png,gallery,Kitten Zack Concept,
-3621,Friaser.png,gallery,,
-8228,evil_mouse_XD.png,gallery,,
-3528,4th_of_july.png,gallery,4th of July,
-9322,teeth.png,gallery,,
-7996,thats_all_she_wrote.png,gallery,That's All She Wrote!,
-2034,Popochi.png,gallery,,
-2051,Mini-Top.png,gallery,MiniTop 8000,
-8219,zc_cooks.png,gallery,Zack Cooks,
-5551,Cirria.png,gallery,,
-4285,o0obubbleso0o_Contest.png,gallery,o0obubbleso0o Contest,
-2849,sallys_dark_world.png,gallery,Sally’s Dark World,
-6237,cookie.png,gallery,Cookie Girl,
-9123,flash_or_paint.PNG,gallery,Flash or Paint?,
-8416,4k_views.png,gallery,,
-3845,when_i_was_little.png,gallery,,
-5583,screaming_doom_flakes.png,gallery,,
-1948,beach_photo.png,gallery,,
-9021,Teki.png,gallery,,
-5659,oh-boy.gif,gallery,,
-5598,why_are_we_doing_this.png,gallery,,
-1744,aotg_color_ref.png,gallery,Attack of the Video Games: Color Reference,
-7593,Sims_Trophie.png,gallery,,
-9471,poke_poke_poke_p2.png,gallery,,
-6112,adorable_z_colored.png,gallery,Adorable Zack,
-5226,win_xp_insane.png,gallery,Windows XP Insane Edition,
-8541,Zindows_Trista.png,gallery,,
-4444,Julie.png,gallery,,
-6668,megawolf.jpg,gallery,,
-6912,oh_no.png,gallery,Oh no!,
-6538,zc_rev08_modelsheet.png,gallery,2008 Revision,
-7458,crazy_artist.png,gallery,,
-8965,shot_microsoft.png,gallery,,
-4633,beach_time.png,gallery,,
-4532,Z_uncolored.png,gallery,Zack Uncolored,
-2685,when_listeing_to_itunes.png,gallery,When Listening To iTunes,
-7835,whatever.png,gallery,,
-6155,of_doom.png,gallery,,
+Id,Filename,Path,Title
+1963,fbdj_wallpaper.png,wallpaper,Furry Blue DJ
+4858,feet_wallpaper.png,wallpaper,Feet!
+1198,mu_wallpaper.png,wallpaper,Mu
+2983,vector_gen_wallpaper.png,wallpaper,Vector Generation
+5059,fanart_wallpaper.png,wallpaper,Fanart Collage
+6815,z_artists_fanclub.png,wallpaper,Z-Artists’ Club by Megawolf77
+1878,christmas_yet.png,wallpaper,Is it Christmas Yet?
+7567,ferret_girl_ch1.md,stories,"Curse of the Ferret Girl, Chapter 1"
+9268,ferret_girl_ch2.md,stories,"Curse of the Ferret Girl, Chapter 2"
+6651,Friends_in_Kimono_by_Popochi.gif,gifts,
+2805,OMG_She_Killed_Mega_by_Coshi_Dragonite.jpg,gifts,
+8067,Z_Marble_by_travisuped.jpg,gifts,
+1422,TJ_by_travisuped.jpg,gifts,
+3593,Oops_by_watthaduece.jpg,gifts,
+5431,YAY_for_Zc456_by_Popochi.jpg,gifts,
+2228,Zs_house_went_BOOOM_by_nannu901.jpg,gifts,
+3128,Make_em_laugh by_ZamieCat.jpg,gifts,
+1019,Think_Z_by_watthaduece 2.jpg,gifts,Think Z by Watthaduece
+3164,zcfan_by_Travis-uped.jpg,gifts,Zack Fan by Travis-uped
+2976,z_yahoo_doodle_by_Megawolf77.png,gifts,
+3650,Stop_n_Swop__by_Milkb0ne.jpg,gifts,
+4607,1st_drawing_of_Z_by_Netoko.png,gifts,
+8149,ZC_Fanart_by_KawaiiNanao.jpg,gifts,
+5212,zc456_got_700_pageviews_by_megawolf77.jpg,gifts,
+3876,Kumori_and_ZC_by_KumoriAikou.jpg,gifts,
+4924,To_Z_by_wild_catgirl_washu.gif,gifts,
+5531,zcfan_colored_by_Travis-uped.jpg,gifts,Zack Fan Colored by Travis-uped
+8942,ZC_by_KumoriAikou.jpg,gifts,
+3119,good_bad_insane_by_shadowwolfmidnight.jpg,gifts,
+8349,It_Angst_Easy_Being_Z_by_watthaduece.jpg,gifts,
+7427,13_K_hits_for_Megawolf_by_Coshi_Dragonite.jpg,gifts,
+5991,ZC_tweakin_by_JamesRocket.png,gifts,
+8567,Think_Z_by_watthaduece.jpg,gifts,
+1467,Zc_D_by_CheetahGal.jpg,gifts,
+6831,Z_Beats_for_Z_Artists_contest__by_megawolf77.png,gifts,
+9767,28_K_for_Lilchu_by_Coshi_Dragonite.jpg,gifts,
+2824,ifIgothacked.jpg,gifts,If I Got Hacked by Travis-uped
+6621,ZC_against_Terry_by_JamesRocket.png,gifts,
+9698,Zc456_Zero_Punctuation_by_Midnight_Vulpin.jpg,gifts,
+5014,ZC_thinks_about_cooking_by_JamesRocket.png,gifts,
+2972,Zc456_has_a_problem_by_Milkb0ne.jpg,gifts,
+3716,Plant_a_Z_Today_by_watthaduece.jpg,gifts,
+7631,Zs_Pocky_Obsession_by_wild_catgirl_washu.jpg,gifts,
+8442,attack_of_the_video_games.gif,animations,Attack of the Video Games
+4294,school.gif,animations,School!
+5264,a_dog.gif,animations,If I Were a Dog
+1743,not_a_puppy.gif,animations,Not a Puppy!
+7168,rvb_z_welcome.png,gallery,Red vs Blue
+1371,black_and_white.png,gallery,
+4234,3k_views.png,gallery,
+6185,you_know_wanna.png,gallery,
+8727,plant_your_butt.png,gallery,
+1502,zc_paint.png,gallery,MS Paint Zack
+9312,above_the_world.png,gallery,Us Against the World
+9866,z_meets_roboz.png,gallery,Zack Meets RoboZ
+2853,sleeping.png,gallery,
+2471,z_goes_camping.png,gallery,Zack Goes Camping
+8729,her_butt_blew_up.png,gallery,
+231,zc_paint_v2.png,gallery,MS Paint Zack v2
+8171,be_my_buddy.png,gallery,
+9215,it_itchs_-_remix.png,gallery,
+6456,spit_bomber_tails.png,gallery,
+3694,gaia_zack.png,gallery,Gaia Zack
+7288,speachless.png,gallery,
+4862,bluefreak.png,gallery,Blue Freak
+9668,moo_XD.png,gallery,Zack with Udders
+1399,mr_green.gif,gallery,
+7718,twilight_z.png,gallery,Twilight Zack
+9097,the_pepsi.png,gallery,
+4467,on_the_train.png,gallery,Night on the Train
+4481,Wonka-z.png,gallery,Wonka Zack
+9185,fried_brain.png,gallery,
+9329,z_djs.jpg,gallery,Zack DJs
+8132,z_gets_flashed.png,gallery,Zack Gets Flashed
+9918,my_green_eggs_and_ham.png,gallery,
+7814,the_future_dj.png,gallery,The Future DJ
+2837,my_brown_poo.png,gallery,
+5247,a_random_hug.png,gallery,
+8095,z_meet_bunni.jpg,gallery,Zack Meets Bunni
+7430,Doom_Flakes.png,gallery,
+8759,alex.png,gallery,
+2173,z_adorable2-5.png,gallery,Adoble Zack 2.5
+8048,is_it_christmas.png,gallery,Is it Christmas Yet?
+2566,Doom_Flakes_-_Popochi.png,gallery,
+1854,killed_sally.png,gallery,
+3993,do_the_bunni.png,gallery,Do the Bunni!
+7025,boxers_of_america.png,gallery,
+5555,get_something_done.png,gallery,
+5869,singing_satellite.gif,gallery,
+4457,zc_2_pixal.png,gallery,Pixel Zack v2
+4126,John_Model_Sheet.png,gallery,John
+7973,kim.png,gallery,
+2962,zc_smile.gif,gallery,Smiley
+7149,woof.png,gallery,
+2657,battery_park.png,gallery,
+7481,gir.png,gallery,
+7312,it_itchs.png,gallery,
+5787,Torro.png,gallery,
+3768,my_tail.jpg,gallery,Keep the Fox Tail
+4384,evil_mw77.png,gallery,Evil Mega
+6122,whos_the_cute_one.png,gallery,Who's the Cute One?
+8215,link_gets_a_hug.png,gallery,
+9289,cat_z.png,gallery,
+3724,rain_go_away.png,gallery,"Rain, Rain Go Away"
+9685,you.png,gallery,You!!!
+1254,super_z.png,gallery,Super Zack!
+3111,for_sam.png,gallery,
+1423,me_as_a_fox.png,gallery,
+7867,mw77.png,gallery,Toon(ish) Mega
+9110,z_kitten_model_sheet_1.png,gallery,Kitten Zack Concept
+3621,Friaser.png,gallery,
+8228,evil_mouse_XD.png,gallery,
+3528,4th_of_july.png,gallery,4th of July
+9322,teeth.png,gallery,
+7996,thats_all_she_wrote.png,gallery,That's All She Wrote!
+2034,Popochi.png,gallery,
+2051,Mini-Top.png,gallery,MiniTop 8000
+8219,zc_cooks.png,gallery,Zack Cooks
+5551,Cirria.png,gallery,
+4285,o0obubbleso0o_Contest.png,gallery,o0obubbleso0o Contest
+2849,sallys_dark_world.png,gallery,Sally’s Dark World
+6237,cookie.png,gallery,Cookie Girl
+9123,flash_or_paint.PNG,gallery,Flash or Paint?
+8416,4k_views.png,gallery,
+3845,when_i_was_little.png,gallery,
+5583,screaming_doom_flakes.png,gallery,
+1948,beach_photo.png,gallery,
+9021,Teki.png,gallery,
+5659,oh-boy.gif,gallery,
+5598,why_are_we_doing_this.png,gallery,
+1744,aotg_color_ref.png,gallery,Attack of the Video Games: Color Reference
+7593,Sims_Trophie.png,gallery,
+9471,poke_poke_poke_p2.png,gallery,
+6112,adorable_z_colored.png,gallery,Adorable Zack
+5226,win_xp_insane.png,gallery,Windows XP Insane Edition
+8541,Zindows_Trista.png,gallery,
+4444,Julie.png,gallery,
+6668,megawolf.jpg,gallery,
+6912,oh_no.png,gallery,Oh no!
+6538,zc_rev08_modelsheet.png,gallery,2008 Revision
+7458,crazy_artist.png,gallery,
+8965,shot_microsoft.png,gallery,
+4633,beach_time.png,gallery,
+4532,Z_uncolored.png,gallery,Zack Uncolored
+2685,when_listeing_to_itunes.png,gallery,When Listening To iTunes
+7835,whatever.png,gallery,
+6155,of_doom.png,gallery,

--- a/src/CaseyUniverse.DOC/wwwroot/stories/ferret_girl_ch1.md
+++ b/src/CaseyUniverse.DOC/wwwroot/stories/ferret_girl_ch1.md
@@ -1,3 +1,7 @@
+---
+authors: Travisuped, ChatGPT.
+---
+
 "Very cute," Z said, drooling.
 
 Terry smiled. "Good!" he replied, grabbing her hand and running away.

--- a/src/CaseyUniverse.DOC/wwwroot/stories/ferret_girl_ch2.md
+++ b/src/CaseyUniverse.DOC/wwwroot/stories/ferret_girl_ch2.md
@@ -1,3 +1,7 @@
+---
+authors: Tony Bark, ChatGPT.
+---
+
 Fireball destroys the sun and Terry, Zack, and Ferret's unnamed sister are
 shot into space. Terry says, "I'm not even going to ask why we got shot
 into space." Zack asks, "I've got a bigger question, why are we able to


### PR DESCRIPTION
- Credits in stories are now handled by YAML front matter
- Viewing gifts will no longer show duplicate credits
- Removed description support in CSV models (it was only used for story credits)
- Added Kumori to the copyrighted characters, and specified which Gir I'm referring to on the same page
- Story detection is now determined by path, like everything else, instead of the file extension
- Moved shading from header to the menu
- The Markdown parser additionally uses SmartyPants module now
- Support for author credit in DynMeta (this is temporary)